### PR TITLE
Remove outdated contact address

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,9 @@ Manter a implementação atual alinhada a:
 
 ## Conteúdo
 
-Use linguagem acolhedora, objetiva e ética. O site pode explicar formação, abordagem clínica, públicos atendidos, endereço, atendimento online e formas de contato.
+Use linguagem acolhedora, objetiva e ética. O site pode explicar formação, abordagem clínica, públicos atendidos, atendimento online e formas de contato.
 
 Evite promessas de cura, garantias de resultado, diagnósticos, aconselhamento psicológico individualizado, depoimentos de pacientes e urgência comercial agressiva. Quando faltar uma informação profissional, não invente.
-
-## Contato
-
-Preserve estes dados enquanto não houver orientação contrária:
-
-- WhatsApp: `https://wa.me/5567996882030`
-- Telefone: `+55 (67) 99688-2030`
-- E-mail: `carlasuzanamarinho@gmail.com`
-- Endereço: `Rua Oliveira Marques, 1430, Centro - Dourados/MS`
-- Formulário: `name="contact"` e `data-netlify="true"`
 
 ## Checklist
 

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -74,13 +74,6 @@
             "founder": {
               "@id": "https://tgmarinho.github.io/csm/#psychologist"
             },
-            "address": {
-              "@type": "PostalAddress",
-              "streetAddress": "Rua Oliveira Marques, 1430, Centro",
-              "addressLocality": "Dourados",
-              "addressRegion": "MS",
-              "addressCountry": "BR"
-            },
             "areaServed": ["Dourados/MS", "Brazil", "Brazilians abroad", "English-speaking people"]
           },
           {

--- a/public/index.html
+++ b/public/index.html
@@ -87,13 +87,6 @@
             "founder": {
               "@id": "https://tgmarinho.github.io/csm/#psychologist"
             },
-            "address": {
-              "@type": "PostalAddress",
-              "streetAddress": "Rua Oliveira Marques, 1430, Centro",
-              "addressLocality": "Dourados",
-              "addressRegion": "MS",
-              "addressCountry": "BR"
-            },
             "areaServed": ["Dourados/MS", "Brasil", "Brasileiros no exterior", "Pessoas que falam inglês"]
           },
           {


### PR DESCRIPTION
Removes the outdated contact preservation block from the README so future edits are not guided by stale address data. Also removes the old street address from the PT and EN structured data while keeping service area metadata intact. Validation: reviewed the full diff against origin/master and confirmed the old street address no longer appears in README.md or public pages.